### PR TITLE
Header rendering as plaintext

### DIFF
--- a/source/posts/3-ruby-can-you-speak-louder.html.md
+++ b/source/posts/3-ruby-can-you-speak-louder.html.md
@@ -76,6 +76,7 @@ Option      | Alias      | Effects
 A funny thing to note is that `-v` is a shortcut for `--version` as well as it is one for `--verbose`.
 
 ## Effect of Debug Modes on Interpreter
+
 ### Verbosity
 
 `$VERBOSE`                        | Effect


### PR DESCRIPTION
Noticed one of the headers was rendering as plaintext due to spacing.