### PR TITLE
Update github ribbon to point to main branch

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -83,4 +83,4 @@ title: "Idiosyncratic Ruby: Documenting All Ruby Specialities"
   </div>
 </div>
 
-<a href="https://github.com/janlelis/idiosyncratic-ruby.com/tree/master/source/posts/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="/images/forkme.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/janlelis/idiosyncratic-ruby.com/tree/main/source/posts/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="/images/forkme.png" alt="Fork me on GitHub"></a>


### PR DESCRIPTION
Looks like the principal branch was changed from `master` to `main`. This fixes the ribbon link to point to the correct branch.