### PR TITLE
Minor: Avoid using octal digit in date example

### DIFF
--- a/source/posts/34-utility-gems.html.md
+++ b/source/posts/34-utility-gems.html.md
@@ -113,7 +113,7 @@ RubyGems also provides a [`deprecate` method](http://docs.seattlerb.org/rubygems
     module Kernel
       extend Gem::Deprecate
       deprecate :puts, :none, 2020, 12
-      deprecate :format, :sprintf, 2016, 05
+      deprecate :format, :sprintf, 2016, 5
     end
 
     puts "test"


### PR DESCRIPTION
As nice as it would be to be able to use leading zeros when representing dates, a leading zero gets interpreted as octal. This means that 08 and 09 don't work and is somewhat confusing/annoying for people not used to octal, so I suggest avoiding them in the example.

(Also, thanks a lot for this project, it's an amazing and high-quality reference!)