### PR TITLE
Fix Atom namespace identifier

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct!
-xml.feed "xmlns" => "https://www.w3.org/2005/Atom" do
+xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   site_url = "https://idiosyncratic-ruby.com/index/"
   xml.title "Idiosyncratic Ruby"
   xml.subtitle "Documenting All Ruby Specialities"


### PR DESCRIPTION
XML namespace identifiers are IRIs. They might look like URLs but they are not. Schema (or any other part) should not be changed. There's usually a page at the same URL to let people know what it is and where it might be documented but that is just a convention and is done for user's convenience.

Specifically in this case Miniflux is unhappy because it doesn't know what this namespace is and it insists on validating it.